### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # @item = Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,8 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class="list">
-            <%= link_to "#" do %>
+            <%# <%= link_to "#" do %> 
+            <%= link_to item_path(item) do %>
               <div class="item-img-content">
               <%= image_tag item.image, class: "item-img" %>
                 <%# <% if item.order.present? %> 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,11 +4,9 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%# <%= "商品名" %> 
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %> 
       <%= image_tag @item.image, class: 'item-img' %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# <div class="sold-out"> %>
@@ -18,33 +16,26 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.shipping_fee_status.name %>
+        <%= number_to_currency(@item.price, unit: "¥", precision: 0) %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_status.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <%# <% elsif user_signed_in? && @item.order.blank? %> 
-      <%# <%= link_to "購入画面に進む", new_item_order_path(@item), class: "item-red-btn" %> 
+      <%= link_to "削除", item_path(@item), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"item-destroy" %>
+    <% elsif user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
     <% end %>
-  
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.name %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if  user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,14 +24,14 @@
     </div>
 
 
-    <% if  user_signed_in?%>
-    <% current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <% else %>
-      <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
-    <% end %>
+    <% if  user_signed_in? %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+      <% end %>
     <% end %>
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,12 +24,14 @@
     </div>
 
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
+    <% if  user_signed_in?%>
+    <% current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", item_path(@item), method: :delete, data: { confirm: "本当に削除しますか？" }, class:"item-destroy" %>
-    <% elsif user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% else %>
       <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
+    <% end %>
     <% end %>
 
 
@@ -100,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,21 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%# <%= "商品名" %> 
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%# <%= image_tag "item-sample.png" ,class:"item-box-img" %> 
+      <%= image_tag @item.image, class: 'item-img' %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.shipping_fee_status.name %>
       </span>
       <span class="item-postage">
         <%= "配送料負担" %>
@@ -24,10 +26,14 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%# <% elsif user_signed_in? && @item.order.blank? %> 
+      <%# <%= link_to "購入画面に進む", new_item_order_path(@item), class: "item-red-btn" %> 
+    <% end %>
+  
 
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
@@ -44,27 +50,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname  %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
- 商品詳細ページに関する各状態での遷移挙動を確認する動画を添付
  - ログイン中のユーザーが、自身の出品商品にアクセスする場合
  - ログイン中のユーザーが、他人の出品商品にアクセスする場合
  - 売却済み商品の詳細ページ表示（購入機能実装済みの前提）
　　　→未実装のため、なし
  - ログアウト状態でも商品詳細にアクセス可能であることの確認



# Why
- 各ユーザー状態・商品状態に応じて、詳細ページが正しく表示されることを保証するため
- 出品者と購入者で挙動や表示内容が変わる場合の検証のため
- 売却済み商品の状態管理・ボタン表示制御の確認のため
　　　→未実装のため、なし
- ゲストユーザーも商品情報を閲覧できる設計かを確認するため


- [ ] ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
　　https://i.gyazo.com/b4672614956adb127531fab259bc679c.gif

- [ ] ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
　　https://i.gyazo.com/e600539c4fad991966ad7d3b8562541a.gif      


- [ ] ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
         未実装のため、なし         


- [ ] ログアウト状態で、商品詳細ページへ遷移した動画
         https://i.gyazo.com/c8add6bce0d29ed368d6dcf9eac5a207.gif

