### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,12 +1,13 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :authorize_user, only: [:edit, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def new
@@ -22,7 +23,26 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def authorize_user
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
 
   def item_params
     params.require(:item).permit(

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,9 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+ 
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id: "item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class: "items-text", id: "item-name", placeholder: "商品名（必須 40文字まで)", maxlength: "40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class: "items-text", id: "item-info", placeholder: "商品の説明（必須 1,000文字まで）", rows: 7, maxlength: 1000 %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, { prompt: "---" }, class: "select-box", id: "item-category" %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :condition_id, Condition.all, :id, :name, { prompt: "---" }, class: "select-box", id: "item-sales-status" %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select :shipping_fee_status_id, ShippingFeeStatus.all, :id, :name, { prompt: "---" }, class: "select-box", id: "item-shipping-fee-status" %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "---" }, class: "select-box", id: "item-prefecture" %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+         <%= f.collection_select :scheduled_delivery_id, ScheduledDelivery.all, :id, :name, { prompt: "---" }, class: "select-box", id: "item-scheduled-delivery" %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,9 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <div class="sell-btn-contents">
+      <%= link_to 'もどる', item_path(@item), class: "back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -103,6 +103,7 @@
           出品をもちまして <a href="#">加盟店規約</a> に同意したことになります。
         </p>
       </div>
+
       <div class="sell-btn-contents">
         <%= f.submit "出品する", class: "sell-btn" %>
         <%= link_to "もどる", root_path, class: "back-btn" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if  user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima42317
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.paths.add 'app/models', eager_load: true
+
     config.active_storage.variant_processor = :mini_magick
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do


### PR DESCRIPTION
# WHAT

- ログイン状態の出品者は、商品情報編集ページに遷移できるようにした
- 正しい情報を入力して「更新する」ボタンを押すと、商品の情報が更新されるようにした
- 入力に問題がある場合、「変更する」ボタンを押しても保存されず、エラーメッセージが表示されるようにした
- 何も編集せず「更新する」を押しても、画像が消えないようにした
- 出品者以外が編集ページへURL直接アクセスした場合、トップページに遷移するようにした
- 出品者であっても、売却済み商品の編集ページへアクセスした場合、トップページに遷移するようにした（購入機能が実装済みの場合）
　→未実装のため、無し
- ログアウト状態で編集ページへURL直接アクセスすると、ログインページに遷移するようにした
- 編集ページにアクセスすると、商品名・カテゴリー等の既存情報がフォームに表示されるようにした（画像・販売手数料・販売利益は表示なしでOK）

# WHY

- 出品者が自身の商品を自由に編集できるようにするため
- 誤った情報の修正を可能にし、ユーザー体験を向上させるため
- バリデーションに失敗したときも適切にエラーメッセージを返すことで、ユーザーの入力ミスを防ぐため
- 編集時に画像を再アップロードしなくても既存画像が維持されるようにして、利便性を高めるため
- 他人の商品情報を編集されないようにして、セキュリティを確保するため
- 売却済み商品を編集不可にすることで、取引情報の整合性を保つため
- 未ログインユーザーが編集ページにアクセスできないようにし、不正利用を防止するため
- 既存の入力内容があらかじめ表示されることで、ユーザーが簡単に修正操作を行えるようにするため


- [ ] ログイン状態の出品者は、商品情報編集ページに遷移できる動画
      https://i.gyazo.com/086c00725279883f668d772a3523d81c.gif

- [ ] 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
       https://i.gyazo.com/9d6219b009ec6b2e5cb88833554bfab9.gif

- [ ] 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
       https://i.gyazo.com/fac6dd4363305182e4e28852e364aa31.gif

- [ ] 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
       https://i.gyazo.com/8a6c1b9c47d99a3c92f29e0644215394.gif


- [ ] ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
        https://i.gyazo.com/1c0ecdac978263c7e1b49ae6f518aa6d.gif


- [ ] ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
　　→未実装のため、無し


- [ ] ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
       https://i.gyazo.com/3f948bda7dc6e06c24d16489d2d3f6d9.gif
        


- [ ] 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
        https://i.gyazo.com/5f2e27c3c395aa260d3927fa14361d1c.gif